### PR TITLE
Add reordering for bias

### DIFF
--- a/duo_attn/patch/utils.py
+++ b/duo_attn/patch/utils.py
@@ -24,6 +24,13 @@ def reorder_linear_weights(
         weight2 = linear_module.weight.data[~full_attn_mask, :]
         reordered_weight = torch.cat([weight1, weight2], dim=0)
     linear_module.weight.data = reordered_weight
+    # for linear modules with bias
+    if linear_module.bias is not None:
+        bias1 = linear_module.bias.data[full_attn_mask]
+        bias2 = linear_module.bias.data[~full_attn_mask]
+        reordered_bias = torch.cat([bias1, bias2], dim=0)
+        linear_module.bias.data = reordered_bias
+
     return linear_module
 
 


### PR DESCRIPTION
Hello, I found that duo-attention does not function correctly for certain models. After extensive debugging, I found that it's because the reordering is not applied to the bias of linear modules. This results in incorrect outputs for models that include bias terms :)